### PR TITLE
Exchange updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # Ignore files containing keys and passwords
 config/*settings.yml
+config/secrets.yml
 
 # Ignore compiled assets
 public/assets/**/*

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,13 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+# Initialize config/secrets.yml if needed
+file 'config/secrets.yml' => 'config/secrets.yml.example' do |task|
+  cp task.prerequisites.first, task.name
+end
+
+Rake::Task['config/secrets.yml'].invoke
+
 require File.expand_path('../config/application', __FILE__)
 
 Exchange::Application.load_tasks

--- a/app/access_policies/application_event_access_policy.rb
+++ b/app/access_policies/application_event_access_policy.rb
@@ -9,7 +9,7 @@ class ApplicationEventAccessPolicy
 
     # The only action for these Events is create
     action == :create && \
-    requestor.platform == application_event.task.identifier.platform
+    requestor.platform == application_event.task.identifier.try(:platform)
   end
 
 end

--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -1,8 +1,8 @@
 OpenStax::Accounts.configure do |config|
   config.openstax_accounts_url = 'http://localhost:2999/' if !Rails.env.production?
   accounts_secrets = Rails.application.secrets['openstax']['accounts']
-  config.openstax_application_id = accounts_secrets['application_uid']
-  config.openstax_application_secret = accounts_secrets['application_secret']
+  config.openstax_application_id = accounts_secrets['application_id']
+  config.openstax_application_secret = accounts_secrets['secret']
   config.logout_via = :delete
   config.enable_stubbing = true
 end

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -17,8 +17,8 @@ defaults: &defaults
   %>
   openstax:
     accounts:
-      application_uid: <%= ENV["OPENSTAX_ACCOUNTS_APPLICATION_UID"] %>
-      application_secret: <%= ENV["OPENSTAX_ACCOUNTS_APPLICATION_SECRET"] %>
+      application_id: <%= ENV["OPENSTAX_ACCOUNTS_APPLICATION_ID"] %>
+      secret: <%= ENV["OPENSTAX_ACCOUNTS_SECRET"] %>
   aws:
     credentials:
       access_key_id: <%= ENV["AWS_CREDENTIALS_ACCESS_KEY_ID"] %>


### PR DESCRIPTION
- Allow Regex trusted hosts
- Changed default trusted host to *.openstax.org
- Automatically generate secrets.yml from example
- Don't error out if identifier not provided for platform events