### PR TITLE
DO NOT MERGE reproduce production error due to failed transaction_retry

### DIFF
--- a/lib/rescue_from_extensions.rb
+++ b/lib/rescue_from_extensions.rb
@@ -1,0 +1,1 @@
+rescue_from_extensions.rb

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ ENV["RAILS_ENV"] ||= 'test'
 # Generates the secrets.yml file if not present
 unless File.exists?('config/secrets.yml')
   require 'rails/generators'
-  Rails::Generators.invoke('secrets') 
+  Rails::Generators.invoke('secrets')
 end
 
 require 'spec_helper'
@@ -35,6 +35,8 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  config.include WithoutException
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/grading_events_post_spec.rb
+++ b/spec/requests/grading_events_post_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+describe "Grading Events Retry Explosion", :type => :request, :api => true, :version => :v1 do
+
+  let!(:platform) { FactoryGirl.create(:platform) }
+  let!(:identifier) { FactoryGirl.create(:identifier, platform: platform) }
+  let!(:platform_access_token) { FactoryGirl.create(:access_token,
+                                   application: platform.application) }
+  let!(:task)  { FactoryGirl.build(:task, identifier: identifier) }
+  let!(:event) { FactoryGirl.build(:grading_event, task: task) }
+
+  it 'does not explode on a transaction retry' do
+
+    # Using JSON borrowed from a real request, just in case (tho actually might not matter)
+    json = {
+      "identifier"=>"#{identifier.write_access_token.token}",
+      "resource"=>"https://exercises.openstax.org/exercises/4623@1",
+      "trial"=>"151379",
+      "grade"=>1,
+      "grader"=>"tutor",
+      "format"=>"json",
+      "controller"=>"api/v1/grading_events",
+      "action"=>"create",
+      "grading_event"=>{"grader"=>"tutor", "grade"=>1}
+    }.to_json
+
+    stub_request(:get, "https://exercises.openstax.org/exercises/4623@1").
+      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
+      to_return(:status => 200, :body => "", :headers => {})
+
+    # To get the transaction to retry (and to simulate what happens in production),
+    # we need to raise an exception the first time through after the event has been
+    # set in the routine outputs.  I picked a call to BL to fake b/c it doesn't impact
+    # the outcome.  On the first call, the BL call raises an exception that triggers
+    # transaction_retry; on the second it doesn't.
+
+    @times_called = 0
+    allow(OpenStax::Biglearn::V1).to receive(:send_response) do
+      @times_called += 1
+      if @times_called == 1
+        raise(::ActiveRecord::TransactionIsolationConflict, 'hi')
+      end
+    end
+
+    # In reality, the Lev routine is the top-level transaction, but rspec has its own
+    # transactions at the top, so we have to fake that the Lev routine transaction
+    # is at the top.
+    allow(ActiveRecord::Base).to receive(:tr_in_nested_transaction?) { false }
+
+    do_not_rescue_exceptions do
+      expect{
+        api_post "/api/events/platforms/gradings", platform_access_token, raw_post_data: json
+      }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/support/rescue_from.rb
+++ b/spec/support/rescue_from.rb
@@ -1,3 +1,23 @@
 OpenStax::RescueFrom.configure do |c|
   c.raise_exceptions = false
 end
+
+module WithoutException
+  def do_not_rescue_exceptions(&block)
+    rescue_exceptions(false, &block)
+  end
+
+  def do_rescue_exceptions(&block)
+    rescue_exceptions(true, &block)
+  end
+
+  def rescue_exceptions(do_rescue, &block)
+    original_raise_exceptions = OpenStax::RescueFrom.configuration.raise_exceptions
+    begin
+      OpenStax::RescueFrom.configuration.raise_exceptions = !do_rescue
+      yield
+    ensure
+      OpenStax::RescueFrom.configuration.raise_exceptions = original_raise_exceptions
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a spec that replicates a production exception.  For whatever reason, a POST to exchange fails because of some Postgres transaction isolation collision.  This causes Lev to retry the transaction (Lev includes transaction_retry).  Unfortunately, Lev set variables during the first transaction that persist when the transaction is repeated, so the routine outputs grow.  Instead of just having one "event" in the routine outputs from this POST, the second transaction retry adds a second "event" output, so that result.outputs[:event] is an array.  This causes Roar to look for a non-existent "GradingEventsRepresenter" (note the pluralization).

If you [put a breakpoint here](https://github.com/openstax/exchange/blob/master/lib/event.rb#L54) you'll see the array of outputs.

I don't think this should be fixed here, but instead in Lev.  The task is to write a Lev spec that shows this same problem and then fix Lev.  The spec should use a simple test routine that sets an output variable and then raises the exception on its first call.  transaction_retry will retry the transaction, and the routine should not `raise` on the second call.  At the end of that second run, the routine should have duplicated output (what we don't want).  

The fix is likely to clear out the result state of the top-level routine (the one that contains the transaction that was retried).  Since the top level routine on its retry will instantiate new subroutines, I don't think they will be a problem, but if you want to be safe you could have the test routine call a lower level routine.  