### PR TITLE
Patch transaction_retry to also retry DB uniqueness violations

### DIFF
--- a/app/routines/create_or_update_activity_from_event.rb
+++ b/app/routines/create_or_update_activity_from_event.rb
@@ -8,7 +8,7 @@ class CreateOrUpdateActivityFromEvent
 
   def exec(activity_class, event, options={})
 
-    activity = activity_class.lock.find_or_initialize_by(task: event.task)
+    activity = activity_class.find_or_initialize_by(task: event.task)
 
     activity.first_event_at ||= Time.now
     activity.last_event_at = Time.now

--- a/app/routines/find_or_create_task.rb
+++ b/app/routines/find_or_create_task.rb
@@ -1,6 +1,6 @@
 class FindOrCreateTask
 
-  lev_routine transaction: :serializable
+  lev_routine
 
   protected
 
@@ -8,9 +8,9 @@ class FindOrCreateTask
   # otherwise saves and returns the task
   def exec(task)
 
-    outputs[:task] = Task.lock.find_by(identifier: task.identifier,
-                                       resource: task.resource,
-                                       trial: task.trial) || task
+    outputs[:task] = Task.find_by(identifier: task.identifier,
+                                  resource: task.resource,
+                                  trial: task.trial) || task
     outputs[:task].save unless outputs[:task].persisted?
     transfer_errors_from(outputs[:task], {type: :verbatim}, true)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,6 @@ module Exchange
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.after_initialize{ require 'transaction_retry_patch' }
   end
 end

--- a/lib/transaction_retry_patch.rb
+++ b/lib/transaction_retry_patch.rb
@@ -1,0 +1,26 @@
+module ActiveRecord
+  RETRYABLE_EXCEPTIONS = [
+    ::ActiveRecord::TransactionIsolationConflict,
+    ::ActiveRecord::RecordNotUnique,
+    ::PG::UniqueViolation
+  ]
+
+  class Base
+    def self.transaction(*objects, &block)
+      retry_count = 0
+
+      begin
+        transaction_without_retry(*objects, &block)
+      rescue *RETRYABLE_EXCEPTIONS
+        raise if retry_count >= TransactionRetry.max_retries
+        raise if tr_in_nested_transaction?
+
+        retry_count += 1
+        postfix = { 1 => 'st', 2 => 'nd', 3 => 'rd' }[retry_count] || 'th'
+        logger.warn "Transaction isolation conflict detected. Retrying for the #{retry_count}-#{postfix} time..." if logger
+        tr_exponential_pause( retry_count )
+        retry
+      end
+    end
+  end
+end


### PR DESCRIPTION
My current understanding of the issue causing the `PG::UniqueViolation` is that, even though the transactions would conflict, the `PG::UniqueViolation` is raised immediately, mid-transaction, if one transaction fully commits before the other one does its insert.

This patch attempts to solve this by adding `::ActiveRecord::RecordNotUnique`, `::PG::UniqueViolation` to the list of exceptions that `transaction_retry` will retry (up to 3 times). Rails will normally catch uniqueness violations during its own validations, unless there's a race condition. So as long as each DB uniqueness constraint has an ActiveRecord validation counterpart, there should be no performance impact (I think).

It also removes the serializable isolation, since the above change should make it unnecessary.