### PR TITLE
use fork of with_advisory_lock to get xact advisory lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem 'pg'
 
 gem 'openstax_rescue_from', '~> 1.5.0'
 
-gem 'with_advisory_lock'
+gem 'with_advisory_lock', git: 'https://github.com/procore/with_advisory_lock.git', ref: 'aba1583c'
 
 group :development, :test do
   # Thin webserver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/procore/with_advisory_lock.git
+  revision: aba1583ce8127370ed7098b03ab5e1952020c295
+  ref: aba1583c
+  specs:
+    with_advisory_lock (3.0.2)
+      activerecord (>= 3.2)
+      thread_safe
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -424,9 +433,6 @@ GEM
       crack (>= 0.3.2)
     whenever (0.9.4)
       chronic (>= 0.6.3)
-    with_advisory_lock (3.0.0)
-      activerecord (>= 3.2)
-      thread_safe
     xml-simple (1.1.5)
     yaml_db (0.3.0)
       rails (>= 3.0, < 4.3)
@@ -498,5 +504,5 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever
-  with_advisory_lock
+  with_advisory_lock!
   yaml_db


### PR DESCRIPTION
Hopefully this clears up advisory locks that occasionally don't get released.