### PR TITLE
switch from coveralls to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ rspec.failures
 # Ignore brakeman reports
 brakeman.html
 
-# Ignore coveralls reports
+# Ignore coverage reports
 coverage/*
 
 # Ignore ERD diagrams

--- a/Gemfile
+++ b/Gemfile
@@ -169,8 +169,8 @@ group :test do
   # Code Climate integration
   gem "codeclimate-test-reporter", require: false
 
-  # Coveralls integration
-  gem 'coveralls', require: false
+  # Codecov integration
+  gem 'codecov', require: false
 end
 
 group :production do

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OpenStax Exchange
 
 [![Build Status](https://travis-ci.org/openstax/exchange.svg?branch=master)](https://travis-ci.org/openstax/exchange)
 [![Code Climate](https://codeclimate.com/github/openstax/exchange.png)](https://codeclimate.com/github/openstax/exchange)
-[![Coverage Status](https://img.shields.io/coveralls/openstax/exchange.svg)](https://coveralls.io/r/openstax/exchange)
+[![Coverage Status](https://img.shields.io/codecov/c/github/openstax/exchange.svg)](https://codecov.io/gh/openstax/exchange)
 
 OpenStax Exchange stores and provides learner interaction "big data".
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,15 @@
-require 'coveralls'
-Coveralls.wear!('rails')
+require 'simplecov'
+require 'codecov'
+
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+SimpleCov.start 'rails'
 
 ENV["RAILS_ENV"] ||= 'test'
 
 # Generates the secrets.yml file if not present
 unless File.exists?('config/secrets.yml')
   require 'rails/generators'
-  Rails::Generators.invoke('secrets') 
+  Rails::Generators.invoke('secrets')
 end
 
 require 'spec_helper'


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this switches from coveralls to codecov.

I was not sure about a couple things but took some defaults:

- When should coveralls make comments on the PR and what should be included
- I used this recommendation from codecov.io: https://github.com/codecov/example-ruby

# Problems

While running `eval "$(rbenv init -)" && gem install bundler && bundle install` I got the same error as https://github.com/openstax/exercises/pull/184 so I was unable to update the `Gemfile.lock` and I do not know how to proceed.
